### PR TITLE
Remove engine mount from within engine routes

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,8 +1,6 @@
 # frozen_string_literal: true
 
 InnerPerformance::Engine.routes.draw do
-  mount InnerPerformance::Engine, at: '/performance'
-
   resources :events, only: [:index]
 
   root to: 'dashboard#index'


### PR DESCRIPTION
This doesnt look like it should be here. Results in engine pages accessible on both `/<my_mount_path>` and `/<my_mount_path>/performance`

I only expected to see this in the spec/dummy app routes files

