### PR TITLE
Remove inner_performance asset includes from dummy app

### DIFF
--- a/spec/dummy/app/assets/config/manifest.js
+++ b/spec/dummy/app/assets/config/manifest.js
@@ -1,3 +1,2 @@
 //= link_tree ../images
 //= link_directory ../stylesheets .css
-//= link inner_performance_manifest.js


### PR DESCRIPTION
No sprockets specific config should exist in the dummy app