### PR TITLE
Remove incorrectly named rubocop file

### DIFF
--- a/rubocop.yml
+++ b/rubocop.yml
@@ -1,4 +1,0 @@
-inherit_from: .rubocop_todo.yml
-
-inherit_gem:
-  rubocop-shopify: rubocop.yml


### PR DESCRIPTION
I dont think this file should be here.

The canonical filename is `.rubocop.yml` (with the dot in front) and that file already exists in this repo.