### PR TITLE
Drop official mysql support

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -29,28 +29,12 @@ jobs:
           POSTGRES_USER: inner_performance
           POSTGRES_PASSWORD: inner_performance
 
-      mysql2:
-        image: mysql:8.0
-        env:
-          MYSQL_ROOT_HOST: "%"
-          MYSQL_DATABASE: inner_performance_test
-          MYSQL_USER: inner_performance
-          MYSQL_PASSWORD: inner_performance
-          MYSQL_ROOT_PASSWORD: inner_performance
-        options: >-
-          --health-cmd "mysqladmin ping"
-          --health-interval 10s
-          --health-timeout 5s
-          --health-retries 3
-        ports:
-          - "3306:3306"
-
     strategy:
       fail-fast: false
       matrix:
         ruby: ["3.2", "3.3"]
         rails_version: ["7.2", "8.0"]
-        db: [sqlite3, postgresql, mysql2]
+        db: [sqlite3, postgresql]
         exclude:
           # Not needed version combinations (just to cut down on noise)
           # 3.1 on 7.0 mainly
@@ -60,12 +44,6 @@ jobs:
           - ruby: 3.1
             rails_version: 7.1
             db: sqlite3
-          - ruby: 3.1
-            rails_version: 7.1
-            db: mysql2
-          - ruby: 3.1
-            rails_version: 7.2
-            db: mysql2
 
           # 3.2 on 7.1 and 7.2 mainly
           - ruby: 3.2
@@ -73,16 +51,10 @@ jobs:
             db: sqlite3
           - ruby: 3.2
             rails_version: 7.0
-            db: mysql2
-          - ruby: 3.2
-            rails_version: 7.0
             db: sqlite3
           - ruby: 3.2
             rails_version: 8.0
             db: sqlite3
-          - ruby: 3.2
-            rails_version: 8.0
-            db: mysql2
           - ruby: 3.3
             rails_version: edge
 
@@ -94,9 +66,6 @@ jobs:
           - ruby: 3.3
             rails_version: 7.2
             db: sqlite3
-          - ruby: 3.3
-            rails_version: 7.2
-            db: mysql2
 
           # Not supported version combinations
           - ruby: 3.1

--- a/spec/gemfiles/rails_7.2.gemfile
+++ b/spec/gemfiles/rails_7.2.gemfile
@@ -7,6 +7,5 @@ eval_gemfile "../../shared.gemfile"
 gem "rails", "~> 7.2.0"
 gem "sprockets-rails", require: "sprockets/railtie"
 
-gem "mysql2", "~> 0.5"
 gem "pg", "~> 1.1"
 gem "sqlite3", ">= 2.1"

--- a/spec/gemfiles/rails_8.0.gemfile
+++ b/spec/gemfiles/rails_8.0.gemfile
@@ -9,4 +9,3 @@ gem "propshaft"
 
 gem "pg", "~> 1.1"
 gem "sqlite3", ">= 2.1"
-gem "mysql2", "~> 0.5"


### PR DESCRIPTION
I personally have no interest in supporting MySQL database engine and it turned out to be ahuge bottleneck when working on new features of InnerPerformance. Therefore, I'm removing it from CI matrix. The support might be revived in the future if there is a need but for now, it was simply not worth the additional hussle. 