### PR TITLE
Wrong create_at format for Traces

### DIFF
--- a/app/models/inner_performance/traces/view.rb
+++ b/app/models/inner_performance/traces/view.rb
@@ -12,7 +12,7 @@ module InnerPerformance
             name: trace[:name],
             payload: trace[:payload].to_json,
             duration: trace[:duration],
-            created_at: trace[:time],
+            created_at: Time.at(trace[:time]),
             event_id: event.id,
           }
         end

--- a/lib/inner_performance/current_request.rb
+++ b/lib/inner_performance/current_request.rb
@@ -31,7 +31,7 @@ module InnerPerformance
     end
 
     def trace(options = {})
-      @traces << options.merge(time: Time.current.to_i)
+      @traces << options.merge(time: Time.current)
     end
   end
 end

--- a/spec/jobs/inner_performance/save_event_job_spec.rb
+++ b/spec/jobs/inner_performance/save_event_job_spec.rb
@@ -17,9 +17,21 @@ describe InnerPerformance::SaveEventJob do
         foo: "bar",
       },
       traces: [
-        { group: :db, name: "sql.active_record", payload: { sql: "SELECT * FROM foo" }, duration: 10, time: Time.current.to_i },
-        { group: :view, name: "render_template.action_view", payload: { identifier: "foo" }, duration: 20, time: Time.current.to_i },
-      ]
+        {
+          group: :db,
+          name: "sql.active_record",
+          payload: { sql: "SELECT * FROM foo" },
+          duration: 10,
+          time: Time.current,
+        },
+        {
+          group: :view,
+          name: "render_template.action_view",
+          payload: { identifier: "foo" },
+          duration: 20,
+          time: Time.current,
+        },
+      ],
     }
   end
 

--- a/spec/models/inner_performance/traces/db_spec.rb
+++ b/spec/models/inner_performance/traces/db_spec.rb
@@ -11,7 +11,7 @@ describe InnerPerformance::Traces::Db do
         name: "sql.active_record",
         payload: { sql: "foo" },
         duration: 123,
-        time: Time.current.to_i,
+        time: Time.current,
       }
     end
 

--- a/spec/models/inner_performance/traces/view_spec.rb
+++ b/spec/models/inner_performance/traces/view_spec.rb
@@ -5,13 +5,14 @@ require "rails_helper"
 describe InnerPerformance::Traces::View do
   describe ".initialize_for_insert" do
     subject { described_class.initialize_for_insert(trace: trace, event: event) }
+    let!(:time) { Time.current }
 
     let(:trace) do
       {
         name: "render_template.action_view",
         payload: { identifier: "foo" },
         duration: 123,
-        time: Time.current.to_i,
+        time: time,
       }
     end
 
@@ -23,7 +24,7 @@ describe InnerPerformance::Traces::View do
         name: "render_template.action_view",
         payload: { identifier: "foo" }.to_json,
         duration: 123,
-        created_at: trace[:time],
+        created_at: time,
         event_id: event.id,
       }))
     end


### PR DESCRIPTION
Saving Trace on Postgres results in:

```
ActiveRecord::StatementInvalid: PG::DatatypeMismatch: ERROR: column "created_at" is of type timestamp without time zone but expression is of type integer LINE 1: ...w', '"{\"identifier\":\"text template\"}"', 0.06, 1739889211... ^ HINT: You will need to rewrite or cast the expression.
```