### PR TITLE
Use #delete in CleanupJob

### DIFF
--- a/app/jobs/inner_performance/cleanup_job.rb
+++ b/app/jobs/inner_performance/cleanup_job.rb
@@ -3,9 +3,14 @@
 module InnerPerformance
   class CleanupJob < ApplicationJob
     def perform
+      InnerPerformance::Trace
+        .joins(:event)
+        .where("inner_performance_events.created_at < ?", InnerPerformance.configuration.events_retention.ago)
+        .delete_all
+
       InnerPerformance::Event
         .where("created_at < ?", InnerPerformance.configuration.events_retention.ago)
-        .destroy_all
+        .delete_all
     end
   end
 end

--- a/spec/factories/traces.rb
+++ b/spec/factories/traces.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+FactoryBot.define do
+  factory :trace, class: "InnerPerformance::Trace" do
+    event
+  end
+end

--- a/spec/jobs/inner_performance/cleanup_job_spec.rb
+++ b/spec/jobs/inner_performance/cleanup_job_spec.rb
@@ -8,7 +8,16 @@ describe InnerPerformance::CleanupJob do
   let!(:old_event) { create(:event, created_at: 7.days.ago) }
   let!(:fresh_event) { create(:event, created_at: 6.days.ago) }
 
-  it "removes jobs older than InnerPerformance.configuration.events_retention" do
+  let!(:old_trace) { create(:trace, event: old_event, created_at: 7.days.ago) }
+  let!(:fresh_trace) { create(:trace, event: fresh_event, created_at: 6.days.ago) }
+
+  it "removes events older than InnerPerformance.configuration.events_retention" do
     expect { subject }.to(change(InnerPerformance::Event.all, :count).by(-1))
+    expect(InnerPerformance::Event.all).to(eq([fresh_event]))
+  end
+
+  it "removes traces older than InnerPerformance.configuration.events_retention" do
+    expect { subject }.to(change(InnerPerformance::Trace.all, :count).by(-1))
+    expect(InnerPerformance::Trace.all).to(eq([fresh_trace]))
   end
 end


### PR DESCRIPTION
It turned out using `#destroy` is too slow for bigger amount of events and traces. If one needs callbacks, custom implementation is gonna be required on the user app end.