### PR TITLE
Make it able to use Decimal numbers as rate values

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ InnerPerformance.configure do |config|
     # your app's performance. As an example: In a Spree shop with
     # approx. 170 requests per minute, keeping it at default 2%
     # provides me more than enough data to analyze and locate the
-    # bottlenecks.
+    # bottlenecks. Value can be both decimal and integer.
     'process_action.action_controller' => (Rails.env.production? ? 2 : 100),
 
     # 100% of all the jobs will be stored and analyzed.

--- a/lib/inner_performance/configuration.rb
+++ b/lib/inner_performance/configuration.rb
@@ -18,7 +18,7 @@ module InnerPerformance
       @events_retention = 1.week
       @medium_duration_range = [200, 999]
       @ignore_rules = [
-        proc { |event| rand(100_000.0) < (InnerPerformance.configuration.sample_rates[event.name.to_s] * 1000) },
+        proc { |event| rand(100_000.0) > (InnerPerformance.configuration.sample_rates[event.name.to_s] * 1000) },
         proc { |event| (event.payload[:job]&.class&.name || "").include?("InnerPerformance") },
       ]
       @cleanup_immediately = false

--- a/lib/inner_performance/configuration.rb
+++ b/lib/inner_performance/configuration.rb
@@ -18,7 +18,7 @@ module InnerPerformance
       @events_retention = 1.week
       @medium_duration_range = [200, 999]
       @ignore_rules = [
-        proc { |event| rand(100) > InnerPerformance.configuration.sample_rates[event.name.to_s] },
+        proc { |event| rand(100_000.0) < (InnerPerformance.configuration.sample_rates[event.name.to_s] * 1000) },
         proc { |event| (event.payload[:job]&.class&.name || "").include?("InnerPerformance") },
       ]
       @cleanup_immediately = false

--- a/spec/lib/inner_performance_spec.rb
+++ b/spec/lib/inner_performance_spec.rb
@@ -32,7 +32,7 @@ describe InnerPerformance do
 
         context "when rand returned number bigger than sample rate" do
           before do
-            allow_any_instance_of(Object).to(receive(:rand).with(100).and_return(101))
+            allow_any_instance_of(Object).to(receive(:rand).with(100_000.0).and_return(100_000.1))
           end
 
           it { is_expected.to(eq(false)) }


### PR DESCRIPTION
It turns out having `process_action.action_controller` rate set to `1` is still too much. This PR is about making it able to set rates to values lower than 1