### PR TITLE
Remove dependency on pagy

### DIFF
--- a/app/controllers/inner_performance/events_controller.rb
+++ b/app/controllers/inner_performance/events_controller.rb
@@ -2,12 +2,24 @@
 
 module InnerPerformance
   class EventsController < ApplicationController
-    include Pagy::Backend
+    RESULTS_PER_PAGE = 50
 
     def index
-      @q = InnerPerformance::Event.all.ransack(params[:q])
+      @current_page = params[:page].presence&.to_i
+
+      if current_page.nil? || current_page < 1
+        @current_page = 1
+      end
+
+      @q = InnerPerformance::Event
+        .all
+        .limit(RESULTS_PER_PAGE)
+        .offset(RESULTS_PER_PAGE * (@current_page - 1))
+        .ransack(params[:q])
+
       @q.sorts = "created_at desc" if @q.sorts.empty?
-      @pagy, @events = pagy(@q.result)
+
+      @events = @q.result
     end
 
     def show

--- a/app/helpers/inner_performance/application_helper.rb
+++ b/app/helpers/inner_performance/application_helper.rb
@@ -2,8 +2,6 @@
 
 module InnerPerformance
   module ApplicationHelper
-    include Pagy::Frontend
-
     # Based on https://stackoverflow.com/a/45428183/552936 and
     # https://datadome.co/learning-center/how-to-reduce-server-response-time/
     def row_class_from_duration(duration)

--- a/app/views/inner_performance/events/index.html.erb
+++ b/app/views/inner_performance/events/index.html.erb
@@ -36,4 +36,12 @@
   </tbody>
 </table>
 
-<%== pagy_nav(@pagy) if @pagy.pages > 1 %>
+<div style="text-align: center;">
+  <% if @current_page > 1 %>
+    <%= link_to "Prev Page", params.to_unsafe_h(page: @current_page - 1), style: "margin-right: 20px;" %>
+  <% end %>
+
+  <% if @events.size == InnerPerformance::EventsController::RESULTS_PER_PAGE %>
+    <%= link_to "Next Page", params.to_unsafe_h(page: @current_page + 1) %>
+  <% end %>
+</div>

--- a/inner_performance.gemspec
+++ b/inner_performance.gemspec
@@ -23,7 +23,6 @@ Gem::Specification.new do |spec|
   end
 
   spec.add_dependency("activejob", ">= 7.1.5")
-  spec.add_dependency("pagy", ">= 9.3.1")
   spec.add_dependency("rails", ">= 7.1.5")
   spec.add_dependency("ransack", ">= 4.2.1")
 

--- a/lib/inner_performance.rb
+++ b/lib/inner_performance.rb
@@ -7,7 +7,6 @@ require "inner_performance/configuration"
 require_relative "inner_performance/current_request"
 
 require "ransack"
-require "pagy"
 
 module InnerPerformance
   class << self


### PR DESCRIPTION
We can just have a simple built-in pagination that uses the ActiveRecord `offset` and `limit` methods. This rails engine is internal facing only so we really dont need anything fancy.

Alternative to #40 